### PR TITLE
build: use venv python instead of system.

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import datetime
 import argparse
 import subprocess


### PR DESCRIPTION
Reason: system python on debian distros may not be new enough to support typing hints.